### PR TITLE
Speed up Travis-CI builds by factor of 9 or so

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,20 @@ language: python
 sudo: false
 python:
   - "2.7"
-virtualenv:
-  system_site_packages: true
-addons:
-  apt:
-    packages:
-    - liblapack-dev
-    - gfortran
 cache:
   directories:
     - $TRAVIS_BUILD_DIR/StochKit2.0.11
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
+  # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
+  - sudo rm -rf /dev/shm
+  - sudo ln -s /run/shm /dev/shm
 install:
-  - pip install sympy networkx matplotlib pygraphviz numpy
-  - pip install -q scipy
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib sympy networkx pygraphviz nose
   - wget http://mmbios.org/index.php/bionetgen-2-2-5-stable/bionetgen-2-2-5-stable-zip?format=raw -O BioNetGen-2.2.5-stable.zip
   - unzip BioNetGen-2.2.5-stable.zip
   - export BNGPATH=`pwd`/BioNetGen-2.2.5-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 sudo: false
 python:
   - "2.7"
+addons:
+  apt:
+    sources:
+    - graphviz
 cache:
   directories:
     - $TRAVIS_BUILD_DIR/StochKit2.0.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib sympy networkx pygraphviz nose
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib sympy networkx nose
+  - conda install --yes -c andreas-wilm pygraphviz
   - wget http://mmbios.org/index.php/bionetgen-2-2-5-stable/bionetgen-2-2-5-stable-zip?format=raw -O BioNetGen-2.2.5-stable.zip
   - unzip BioNetGen-2.2.5-stable.zip
   - export BNGPATH=`pwd`/BioNetGen-2.2.5-stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
-  # The next couple lines fix a crash with multiprocessing on Travis and are not specific to using Miniconda
-  - sudo rm -rf /dev/shm
-  - sudo ln -s /run/shm /dev/shm
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib sympy networkx pygraphviz nose
   - wget http://mmbios.org/index.php/bionetgen-2-2-5-stable/bionetgen-2-2-5-stable-zip?format=raw -O BioNetGen-2.2.5-stable.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ install:
   - git clone https://github.com/JohnAbel/gillespy.git
   - cd gillespy && STOCHKIT_HOME=$HOME/StochKit2.0.11/ python setup.py install && cd ..
 script: nosetests
-notifications:
-  slack: lopezlab:6RrEQYyVeSjYJKLWTovcqiM1
+#notifications:
+#  slack: lopezlab:6RrEQYyVeSjYJKLWTovcqiM1

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ install:
   - git clone https://github.com/JohnAbel/gillespy.git
   - cd gillespy && STOCHKIT_HOME=$HOME/StochKit2.0.11/ python setup.py install && cd ..
 script: nosetests
-#notifications:
-#  slack: lopezlab:6RrEQYyVeSjYJKLWTovcqiM1
+notifications:
+  slack: lopezlab:6RrEQYyVeSjYJKLWTovcqiM1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 addons:
   apt:
     sources:
-    - graphviz
+    - libgraphviz-dev
 cache:
   directories:
     - $TRAVIS_BUILD_DIR/StochKit2.0.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - conda update --yes conda
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib sympy networkx nose
-  - conda install --yes -c andreas-wilm pygraphviz
+  - pip install -i https://pypi.binstar.org/pypi/simple pygraphviz
   - wget http://mmbios.org/index.php/bionetgen-2-2-5-stable/bionetgen-2-2-5-stable-zip?format=raw -O BioNetGen-2.2.5-stable.zip
   - unzip BioNetGen-2.2.5-stable.zip
   - export BNGPATH=`pwd`/BioNetGen-2.2.5-stable


### PR DESCRIPTION
Use [http://conda.pydata.org/miniconda.html](miniconda), a python binary installer tool, to install many of our python dependencies (numpy, scipy etc.) with binaries rather than building from source. This drastically speeds up our Travis build & unit testing time from ~10 mins to a little over 1 minute.