### PR TITLE
Adding logic to download python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ addons:
             - opam
             - aspcud
 before_install:
-- wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-    -O miniconda.sh
+- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+  else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  fi
 - chmod +x miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda
 - export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
Travis build currently download and install python3, then downgrade to python2 after installation for the python2 build. This prevents that and downloads python2 for python2 builds and python3 for python3 builds.