### PR TITLE
Fix altered matplotlib API call

### DIFF
--- a/pysb/tools/sensitivity_analysis.py
+++ b/pysb/tools/sensitivity_analysis.py
@@ -660,7 +660,7 @@ class PairwiseSensitivity(object):
         # create boxplot of single parameter sensitivities
         ax2 = plt.subplot(gs2[1])
         x = [np.array(mat).flatten() for mat in sens_ij_nm[::-1]]
-        ax2.boxplot(x, vert=False, labels=None, showfliers=True, whis='range')
+        ax2.boxplot(x, vert=False, labels=None, showfliers=True, whis=(0, 100))
         ax2.set_xlim(v_min - 2, v_max + 2)
         if x_axis_label is not None:
             ax2.set_xlabel(x_axis_label, fontsize=12)


### PR DESCRIPTION
Specifically, accepted values for the `whis` argument to
matplotlib.pyplot.boxplot no longer includes the string literal
'range'. Instead, supply a tuple `(0, 100)`, indicating the same
thing with percentiles.